### PR TITLE
Rewrite <CODE BEGINS> matching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.6
-pyang==2.4.0
+pyang>=2.5.0


### PR DESCRIPTION
The logic for matching `<CODE BEGINS>` tags has been rewritten to allow matching unquoted file names and other minor anomalies. Errors which were triggered when a `SHOULD` recommendation from an RFC was not followed have been downgraded to warnings.