### PR TITLE
Fix quotes in <CODE BEGINS> header on different lines

### DIFF
--- a/xym/xym.py
+++ b/xym/xym.py
@@ -512,7 +512,7 @@ class YangModuleExtractor:
                 output_file = None
                 code_section_start = None
 
-            if "\"" in line:
+            if level != 0 and "\"" in line:
                 if line.count("\"") % 2 == 0:
                     quotes = 0
                 else:


### PR DESCRIPTION
The closing quote wouldn't get counted because the check for quotes happens before the `<CODE BEGINS>` header is merged into a single line. The workaround is to stop checking for quotes unless we are inside a module.