### PR TITLE
fix: empty directories with code snippets won't be created

### DIFF
--- a/xym/xym.py
+++ b/xym/xym.py
@@ -687,6 +687,8 @@ class YangModuleExtractor:
             self.error("Line %d - Missing <CODE ENDS>" % i)
 
     def write_code_snippets_to_files(self):
+        if not self.code_snippets:
+            return
         os.makedirs(self.code_snippets_dir, exist_ok=True)
         for index, code_snippet in enumerate(self.code_snippets):
             filename = str(index) + '.txt'


### PR DESCRIPTION
From now on, a directory with code snippets will only be created if there are code snippets for the module

resolves #56 