### PR TITLE
ignore module declarations within quoted strings

### DIFF
--- a/xym/xym.py
+++ b/xym/xym.py
@@ -564,9 +564,9 @@ class YangModuleExtractor:
 
             # Try to match '(sub)module <module_name> {'
             match = self.MODULE_STATEMENT.match(line)
-            if not in_code_snippet and match:
+            if not in_code_snippet and match and quotes == 0:
                 # We're already parsing a module
-                if level:
+                if level > 0:
                     self.error("Line %d - 'module' statement within another module" % i)
                     return
 


### PR DESCRIPTION
This allows for modules to include examples of other modules in their description strings.