### PR TITLE
Be less greedy with regex matching.

### DIFF
--- a/xym/xym.py
+++ b/xym/xym.py
@@ -711,7 +711,7 @@ class YangModuleExtractor:
             if '<CODE BEGINS>' in sourcecode.text:
                 # First try and just get the text.
                 matches = re.search(
-                    r"""<CODE BEGINS> file "(([^@]+)@.+)"\n(.+)\n<CODE ENDS>""",
+                    r"""<CODE BEGINS> file "(([^@]+)@[^"]+)"\n(.+)\n<CODE ENDS>""",
                     sourcecode.text,
                     re.M | re.DOTALL,
                 )


### PR DESCRIPTION
We were seeing errors like:

```text
Extracting 'ietf-traffic-map'
[Errno 63] File name too long: './ietf-traffic-map@2024-10-20.yang"\nmodule ietf-traffic-map {\n  yang-version 1.1;\n  namespace "urn:ietf:params:xml:ns:yang:ietf-traffic-map";\n  prefix tm;\n\n  import ietf-inet-types {\n    prefix inet;\n    reference\n...
```

With this change, we specifically stop matching when we see that first quote.