### PR TITLE
Use lxml for XML extraction.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.6
 pyang>=2.5.0
+lxml

--- a/xym/xym.py
+++ b/xym/xym.py
@@ -7,7 +7,7 @@ import os
 import os.path
 import re
 import sys
-import xml.etree.ElementTree as ET
+from lxml import etree as ET
 from collections import Counter
 
 import requests
@@ -699,7 +699,10 @@ class YangModuleExtractor:
                     code_snippet_file.write(line)
 
     def extract_yang_model_xml(self, content):
-        root = ET.fromstring(content)
+        doc_parser = ET.XMLParser(
+            resolve_entities=False, recover=True, ns_clean=True, encoding="utf-8"
+        )
+        root = ET.fromstring(content.encode("utf-8"), doc_parser)
         for sourcecode in root.iter("sourcecode"):
             if not sourcecode.text:
                 continue

--- a/xym/xym.py
+++ b/xym/xym.py
@@ -740,7 +740,8 @@ class YangModuleExtractor:
                 match = self.MODULE_STATEMENT.match(line)
             if match is None:
                 continue
-            lines = lines[i:]
+            mstart = i - 1
+            lines = lines[mstart:]
             if not output_file:
                 self.warning('Missing file name in <sourcecode>')
             if match.group(2) or match.group(5):
@@ -842,8 +843,12 @@ if __name__ == "__main__":
     parser.add_argument("source",
                         help="The URL or file name of the RFC/draft text from "
                              "which to get the model")
-    parser.add_argument("--rfcxml", action='store_ture', default=False,
-                        help="Parse a file in RFCXMLv3 format")
+    parser.add_argument(
+        "--rfcxml",
+        action="store_true",
+        default=False,
+        help="Parse a file in RFCXMLv3 format",
+    )
     parser.add_argument("--srcdir", default='.',
                         help="Optional: directory where to find the source "
                              "text; default is './'")


### PR DESCRIPTION
Pyang already requires lxml, so this isn't technically a new requirement.  Lxml is also much more powerful and flexible when it comes to parsing XML. . The builtin xml library dies on unknown entities, whereas lxml allows us to skip them.