### PR TITLE
fix: API breakage introduced in YANG Semver work.

### DIFF
--- a/xym/xym.py
+++ b/xym/xym.py
@@ -189,7 +189,7 @@ class YangModuleExtractor:
 
         return mname + mrev + mver
 
-    def get_extracted_models(self, force_revision_pyang, force_revision_regexp, extract_semver, semver_symlink):
+    def get_extracted_models(self, force_revision_pyang, force_revision_regexp, extract_semver=False, semver_symlink=False):
         if force_revision_pyang or force_revision_regexp:
             models = []
             models.extend(self.extracted_models)


### PR DESCRIPTION
Apparently, DataTracker uses get_extracted_models() directly (see https://github.com/ietf-tools/datatracker/pull/10939).  When I added the YANG Semver arguments, I did not use defaults thinking they'd come from the calling method.  This is bad public API practice.